### PR TITLE
OnfidoRequestError: Propagate error to exception

### DIFF
--- a/onfido/exceptions.py
+++ b/onfido/exceptions.py
@@ -35,7 +35,12 @@ def error_decorator(func):
             if e.response.status_code >= 500:
                 raise OnfidoServerError() from e
             else:
-                raise OnfidoRequestError() from e
+                error = None
+                if e.response.status_code == 422:
+                    resp_json = e.response.json()
+                    if resp_json:
+                        error = resp_json.get("error")
+                raise OnfidoRequestError(error) from e
 
         except requests.Timeout as e:
             raise OnfidoTimeoutError(e)

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,4 +1,5 @@
 import onfido
+from onfido.exceptions import OnfidoRequestError
 from onfido.regions import Region
 import pytest
 import io
@@ -19,6 +20,34 @@ def test_upload_document(requests_mock):
     api.document.upload(sample_file, request_body)
 
     assert mock_upload.called is True
+
+def test_upload_document_validation_error(requests_mock):
+    mock_upload = requests_mock.post(
+        "https://api.eu.onfido.com/v3.3/documents/",
+        json={
+            "error": {
+                "type": "validation_error",
+                "message": "There was a validation error on this request",
+                "fields": {
+                    "document_detection": [
+                        "no document in image"
+                    ]
+                },
+            }
+        },
+        status_code=422
+    )
+
+    sample_file = open("sample_driving_licence.png", "rb")
+    request_body = {"applicant_id": fake_uuid,
+                    "document_type": "driving_licence",
+                    "validate_image_quality": True}
+
+    with pytest.raises(OnfidoRequestError) as error:
+        api.document.upload(sample_file, request_body)
+
+    assert mock_upload.called is True
+    assert error.value.args[0]['fields']['document_detection']
 
 def test_upload_document_missing_params():
     string_io = io.StringIO("Data to be uploaded")

--- a/tests/test_live_photos.py
+++ b/tests/test_live_photos.py
@@ -1,6 +1,8 @@
 import onfido
+from onfido.exceptions import OnfidoRequestError
 from onfido.regions import Region
 import io
+import pytest
 
 api = onfido.Api("<AN_API_TOKEN>", region=Region.EU)
 
@@ -17,6 +19,32 @@ def test_upload_photo(requests_mock):
 
     assert mock_upload.called is True
 
+def test_upload_live_photo_validation_error(requests_mock):
+    mock_upload = requests_mock.post(
+        "https://api.eu.onfido.com/v3.3/live_photos/",
+        json={
+            "error": {
+                "type": "validation_error",
+                "message": "There was a validation error on this request",
+                "fields": {
+                    "face_detection": [
+                        "Face not detected in image. Please note this validation can be disabled by setting the advanced_validation parameter to false."
+                    ]
+                },
+            }
+        },
+        status_code=422
+    )
+
+    sample_file = open("sample_photo.png", "rb")
+    request_body = {"advanced_validation": "true"}
+
+    with pytest.raises(OnfidoRequestError) as error:
+        api.live_photo.upload(sample_file, request_body)
+
+    assert mock_upload.called is True
+    assert error.value.args[0]['fields']['face_detection']
+        
 def test_find_live_photo(requests_mock):
     mock_find = requests_mock.get(f"https://api.eu.onfido.com/v3.3/live_photos/{fake_uuid}", json=[])
     api.live_photo.find(fake_uuid)


### PR DESCRIPTION
When uploading a live photo it is possible to set the
`advanced_validation` argument and have a synchronous error reporting
on the image, such as when there are no faces present in the image. [1]

However, `error_decorator()` would simply throw an `OnfidoRequestError`
exception without letting us know about the error, making it impossible
to derive (and request the user to re-take the image thereof).

The above is also true for the image quality check [2], getting the
error and checking it will allow servers that use the Onfido Python API
to request its users to re-take the image.

For example:
```Python
try:
    api.live_photo.upload(f, body)
except OnfidoRequestError as error:
    if error['fields']['face_detection']:
        print("No faces detected in image!")
    else:
        print("Unknown error in Onfido's response!")
        print(error)
```

1. https://documentation.onfido.com/#upload-live-photo
2. https://documentation.onfido.com/#image-quality